### PR TITLE
Fix sidebar navigation arrow

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -139,3 +139,7 @@
     display: flex;
   }
 }
+
+.rotateIcon {
+  transform: rotate(180deg);
+}

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,9 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={`${styles.collapseMenuItem} ${
+                isSidebarCollapsed ? styles.rotateIcon : ""
+              } `}
             />
           </ul>
         </nav>


### PR DESCRIPTION
This PR fixes the issue of the collapse arrow icon not pointing to the right after the navigation sidebar has been collapsed. A class by the name of rotateIcon has been created in which it rotates the object 180 degrees. In the Collapse component, within className, rotateIcon is added if the sidebar is collapsed using a ternary operator.