### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -42,6 +42,21 @@ describe("Sidebar Navigation", () => {
       // check that text is not rendered
       cy.get("nav").contains("Issues").should("not.exist");
     });
+    it("shows large logo when switching to landscape mode while navigstion is collapsed", () => {
+      // collapse navigation
+      cy.get("nav").contains("Collapse").click();
+
+      // check that small logo is shown
+      cy.get("img[src='/icons/logo-small.svg']").should("be.visible");
+      cy.get("img[src='/icons/logo-large.svg']").should("not.be.visible");
+
+      // switch to landscape mode that uses the mobile menu
+      cy.viewport(900, 1025);
+
+      // check that large logo is shown'
+      cy.get("img[src='/icons/logo-small.svg']").should("not.be.visible");
+      cy.get("img[src='/icons/logo-large.svg']").should("be.visible");
+    });
   });
 
   context("mobile resolution", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -18,10 +18,6 @@
   &.isCollapsed {
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
-
-      .logo {
-        width: 1.4375rem;
-      }
     }
   }
 }
@@ -49,8 +45,6 @@
 }
 
 .logo {
-  width: 7.375rem;
-
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
   }
@@ -142,4 +136,27 @@
 
 .rotateIcon {
   transform: rotate(180deg);
+}
+
+.logoSmall {
+  composes: logo;
+  width: 1.4375rem;
+  display: none;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: block;
+    }
+  }
+}
+
+.logoLarge {
+  composes: logo;
+  width: 7.375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: none;
+    }
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -36,13 +36,20 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src="/icons/logo-small.svg"
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.logoSmall,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+          <img
+            src="/icons/logo-large.svg"
+            alt="logo"
+            className={classNames(
+              styles.logoLarge,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}


### PR DESCRIPTION
This PR fixes an issue where When a user switches device orientation in a way that results in a change from desktop to mobile mode the small logo is shown instead of the large one. Now the large logo is shown instead while the small logo is hidden.